### PR TITLE
Don't sync UISAVE.DAT

### DIFF
--- a/Dalamud.CharacterSync/CharacterSyncPlugin.cs
+++ b/Dalamud.CharacterSync/CharacterSyncPlugin.cs
@@ -51,7 +51,7 @@ namespace Dalamud.CharacterSync
 
         public Hook<CreateFileWDelegate> _createFileHook;
 
-        private Regex saveFolderRegex = new Regex(@"(.*)FFXIV_CHR(.*)\/(?!ITEMODR\.DAT|ITEMFDR\.DAT|GEARSET\.DAT|.*\.log)(.*)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private Regex saveFolderRegex = new Regex(@"(.*)FFXIV_CHR(.*)\/(?!ITEMODR\.DAT|ITEMFDR\.DAT|GEARSET\.DAT|UISAVE\.DAT|.*\.log)(.*)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public IntPtr CreateFileWDetour(
             [MarshalAs(UnmanagedType.LPWStr)] string filename,

--- a/Dalamud.CharacterSync/Dalamud.CharacterSync.csproj
+++ b/Dalamud.CharacterSync/Dalamud.CharacterSync.csproj
@@ -32,27 +32,27 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dalamud">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="EasyHook">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\EasyHook.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\EasyHook.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ImGui.NET">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ImGuiScene">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Lumina">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\Lumina.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\Lumina.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SDL2-CS">
-      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\SDL2-CS.dll</HintPath>
+      <HintPath>$(USERPROFILE)\AppData\Roaming\XIVLauncher\addon\Hooks\SDL2-CS.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
PR to exclude UISAVE.DAT from syncing, since syncing it can mess up sent mail history, friends groups, recent contacts, CWLS slot assignments, and a few other things that (mostly) don't transfer well across characters.

Also set the project's assembly references with HintPaths that are more likely to work for most people's local directory structure.