### PR TITLE
Cut down on REWRITE spam in log

### DIFF
--- a/Dalamud.CharacterSync/CharacterSyncPlugin.cs
+++ b/Dalamud.CharacterSync/CharacterSyncPlugin.cs
@@ -126,7 +126,7 @@ namespace Dalamud.CharacterSync
                         }
 
                         filename = $"{match.Groups[1].Value}FFXIV_CHR{Config.Cid:X16}/{match.Groups[3].Value}";
-                        PluginLog.Log("REWRITE: " + filename);
+                        PluginLog.LogVerbose("REWRITE: " + filename);
                     }
                 }
 


### PR DESCRIPTION
Made the REWRITE log go to Verbose. It tends to flood the dalamudlog when set to information