### PR TITLE
Update for 6.1

### DIFF
--- a/Dalamud.CharacterSync/Dalamud.CharacterSync.csproj
+++ b/Dalamud.CharacterSync/Dalamud.CharacterSync.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>2.0.0.4</AssemblyVersion>
+    <AssemblyVersion>2.0.0.5</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.5" />
+    <PackageReference Include="DalamudPackager" Version="2.1.6" />
     <Reference Include="Dalamud" Private="False" />
     <Reference Include="ImGui.NET" Private="False" />
     <Reference Include="ImGuiScene" Private="False" />


### PR DESCRIPTION
Quick fix? This should fix the "out of date" message and allow people to use it again.

fixes #12 